### PR TITLE
Added uniform scaling to enforce joint velocity limits

### DIFF
--- a/moveit_experimental/jog_arm/include/jog_arm/jog_calcs.h
+++ b/moveit_experimental/jog_arm/include/jog_arm/jog_calcs.h
@@ -77,6 +77,9 @@ protected:
 
   bool addJointIncrements(sensor_msgs::JointState& output, const Eigen::VectorXd& increments) const;
 
+  // Scale the delta theta to match joint velocity limits. Uniform scaling
+  void enforceJointVelocityLimits(Eigen::VectorXd& calculated_joint_velocity);
+
   // Reset the data stored in low-pass filters so the trajectory won't jump when jogging is resumed.
   void resetVelocityFilters();
 


### PR DESCRIPTION
### Description

Locked the maximum delta theta to the joint speed limit. Then scaled each delta theta component by the amount needed to get the maximum one down to its limit. This should scale the Cartesian uniformly, and keep the robot motion as desired but slower

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
